### PR TITLE
Begin and CoBegin

### DIFF
--- a/do.go
+++ b/do.go
@@ -6,31 +6,6 @@ import (
 	"sync"
 )
 
-// ForAll items in the data set, apply the function. The function accepts the
-// index of the item to which is it being applied. One goroutine is launched
-// for each CPU, so the given function must be safe to use concurrently.
-func ForAll(data interface{}, f func(i int)) {
-	switch reflect.TypeOf(data).Kind() {
-	case reflect.Array, reflect.Map, reflect.Slice:
-		// Calculate workload size per CPU.
-		length := reflect.ValueOf(data).Len()
-		numCPUs := runtime.NumCPU()
-		numIterationsPerCPU := (length / numCPUs) + 1
-		// Apply the function in parallel over the data.
-		var wg sync.WaitGroup
-		wg.Add(numCPUs)
-		for offset := 0; offset < length; offset += numIterationsPerCPU {
-			go func(offset int) {
-				defer wg.Done()
-				for i := offset; i < offset+numIterationsPerCPU && i < length; i++ {
-					f(i)
-				}
-			}(offset)
-		}
-		wg.Wait()
-	}
-}
-
 // Option types are returned from Process functions. They are either a value or
 // an error. The error should be checked before using the value.
 type Option struct {
@@ -52,12 +27,110 @@ func Err(err error) Option {
 	}
 }
 
-// Process runs the function in a goroutine and writes the return value to a
+// Then runs the function on the Option value, if there is no error in the
+// Option. In all other cases it returns the Option unmodified.
+func (option Option) Then(f func(ok interface{}) Option) Option {
+	if option.Err != nil {
+		return option
+	}
+	return f(option.Ok)
+}
+
+// Catch runs the function on the Option error, if there is an error in the
+// Option. In all other cases it returns the Option unmodified.
+func (option Option) Catch(f func(err error) Option) Option {
+	if option.Err != nil {
+		return f(option.Err)
+	}
+	return option
+}
+
+// ForAll items in the data set, apply the function. The function accepts the
+// index of the item to which is it being applied. One goroutine is launched
+// for each CPU, so the given function must be safe to use concurrently.
+func ForAll(data interface{}, f func(i int)) {
+	switch reflect.TypeOf(data).Kind() {
+	case reflect.Array, reflect.Slice:
+		// Calculate workload size per CPU.
+		length := reflect.ValueOf(data).Len()
+		numCPUs := runtime.NumCPU()
+		numIterationsPerCPU := (length / numCPUs) + 1
+		// Apply the function in parallel over the data.
+		var wg sync.WaitGroup
+		wg.Add(numCPUs)
+		for offset := 0; offset < length; offset += numIterationsPerCPU {
+			go func(offset int) {
+				defer wg.Done()
+				for i := offset; i < offset+numIterationsPerCPU && i < length; i++ {
+					f(i)
+				}
+			}(offset)
+		}
+		wg.Wait()
+	}
+}
+
+// Process runs each function in a goroutine and writes the return values to a
 // channel.
-func Process(f func() Option) chan Option {
+func Process(fs ...func() Option) chan Option {
 	ch := make(chan Option)
+
+	// Create a wait group for all processes.
+	var wg sync.WaitGroup
+	wg.Add(len(fs))
+	for _, f := range fs {
+		go func(f func() Option) {
+			defer wg.Done()
+			ch <- f()
+		}(f)
+	}
+
+	// Run a goroutine that will close the channel when all processes have
+	// terminated.
 	go func() {
-		ch <- f()
+		defer close(ch)
+		wg.Wait()
 	}()
+
 	return ch
+}
+
+// CoBegin runs each function on a goroutine and blocks until all functions
+// have terminated. It returns a list of the values produced by each function.
+func CoBegin(fs ...func() Option) []Option {
+	output := make([]Option, len(fs))
+	var wg sync.WaitGroup
+	wg.Add(len(fs))
+	for i, f := range fs {
+		go func(i int, f func() Option) {
+			defer wg.Done()
+			output[i] = f()
+		}(i, f)
+	}
+	wg.Wait()
+	return output
+}
+
+// Begin is similar to CoBegin except that it does not use one gorouting per
+// function. Instead it distributes the functions evenly over a number of
+// goroutines equal to the number of CPUs.
+func Begin(fs ...func() Option) []Option {
+	// Calculate workload size per CPU.
+	length := len(fs)
+	numCPUs := runtime.NumCPU()
+	numIterationsPerCPU := (length / numCPUs) + 1
+	// Apply the functions in parallel.
+	output := make([]Option, length)
+	var wg sync.WaitGroup
+	wg.Add(numCPUs)
+	for offset := 0; offset < length; offset += numIterationsPerCPU {
+		go func(offset int) {
+			defer wg.Done()
+			for i := offset; i < offset+numIterationsPerCPU && i < length; i++ {
+				output[i] = fs[i]()
+			}
+		}(offset)
+	}
+	wg.Wait()
+	return output
 }

--- a/do.go
+++ b/do.go
@@ -57,8 +57,8 @@ func ForAll(data interface{}, f func(i int)) {
 		numIterationsPerCPU := (length / numCPUs) + 1
 		// Apply the function in parallel over the data.
 		var wg sync.WaitGroup
-		wg.Add(numCPUs)
 		for offset := 0; offset < length; offset += numIterationsPerCPU {
+			wg.Add(1)
 			go func(offset int) {
 				defer wg.Done()
 				for i := offset; i < offset+numIterationsPerCPU && i < length; i++ {
@@ -122,8 +122,8 @@ func Begin(fs ...func() Option) []Option {
 	// Apply the functions in parallel.
 	output := make([]Option, length)
 	var wg sync.WaitGroup
-	wg.Add(numCPUs)
 	for offset := 0; offset < length; offset += numIterationsPerCPU {
+		wg.Add(1)
 		go func(offset int) {
 			defer wg.Done()
 			for i := offset; i < offset+numIterationsPerCPU && i < length; i++ {

--- a/do_test.go
+++ b/do_test.go
@@ -70,4 +70,34 @@ var _ = Describe("Concurrency", func() {
 		})
 	})
 
+	Context("when using begin", func() {
+		It("should wait until all functions have terminated", func() {
+			i := int64(0)
+			Begin(func() Option {
+				atomic.AddInt64(&i, 1)
+				return Ok(nil)
+			}, func() Option {
+				atomic.AddInt64(&i, 2)
+				return Ok(nil)
+			}, func() Option {
+				atomic.AddInt64(&i, 3)
+				return Ok(nil)
+			})
+			Ω(i).Should(Equal(int64(6)))
+		})
+
+		It("should collect all function return values", func() {
+			results := Begin(func() Option {
+				return Ok(0)
+			}, func() Option {
+				return Ok(1)
+			}, func() Option {
+				return Ok(2)
+			})
+			Ω(results[0].Ok).Should(Equal(0))
+			Ω(results[1].Ok).Should(Equal(1))
+			Ω(results[2].Ok).Should(Equal(2))
+		})
+	})
+
 })

--- a/do_test.go
+++ b/do_test.go
@@ -12,6 +12,21 @@ import (
 
 var _ = Describe("Concurrency", func() {
 
+	Context("when using an optional value", func() {
+		It("should correctly chain calls to then", func() {
+			Ok(true).Then(func(ok interface{}) Option {
+				Ω(ok).Should(Equal(true))
+				return Ok(true)
+			}).Then(func(ok interface{}) Option {
+				Ω(ok).Should(Equal(true))
+				return Err(errors.New("this is an error"))
+			}).Then(func(err interface{}) Option {
+				Ω(true).Should(Equal(false))
+				return Err(nil)
+			})
+		})
+	})
+
 	Context("when using a for all loop", func() {
 		It("should apply the function to all items", func() {
 			xs := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}

--- a/do_test.go
+++ b/do_test.go
@@ -13,17 +13,32 @@ import (
 var _ = Describe("Concurrency", func() {
 
 	Context("when using an optional value", func() {
-		It("should correctly chain calls to then", func() {
+		It("should correctly execute calls to then", func() {
+			i := 0
 			Ok(true).Then(func(ok interface{}) Option {
-				Ω(ok).Should(Equal(true))
-				return Ok(true)
-			}).Then(func(ok interface{}) Option {
+				i++
 				Ω(ok).Should(Equal(true))
 				return Err(errors.New("this is an error"))
-			}).Then(func(err interface{}) Option {
+			}).Then(func(ok interface{}) Option {
+				i++
 				Ω(true).Should(Equal(false))
 				return Err(nil)
 			})
+			Ω(i).Should(Equal(1))
+		})
+
+		It("should correctly execute calls to catch", func() {
+			i := 0
+			Err(errors.New("this is an error")).Then(func(ok interface{}) Option {
+				i++
+				Ω(true).Should(Equal(false))
+				return Ok(true)
+			}).Catch(func(err error) Option {
+				i++
+				Ω(err).Should(HaveOccurred())
+				return Err(nil)
+			})
+			Ω(i).Should(Equal(1))
 		})
 	})
 

--- a/do_test.go
+++ b/do_test.go
@@ -16,29 +16,53 @@ var _ = Describe("Concurrency", func() {
 		It("should correctly execute calls to then", func() {
 			i := 0
 			Ok(true).Then(func(ok interface{}) Option {
+				// This should happen.
 				i++
 				Ω(ok).Should(Equal(true))
-				return Err(errors.New("this is an error"))
+				return Ok(true)
 			}).Then(func(ok interface{}) Option {
+				// This should happen.
+				i++
+				Ω(ok).Should(Equal(true))
+				return Ok(true)
+			}).Catch(func(err error) Option {
+				// This should not happen.
 				i++
 				Ω(true).Should(Equal(false))
 				return Err(nil)
+			}).Then(func(ok interface{}) Option {
+				// This should happen.
+				i++
+				Ω(ok).Should(Equal(true))
+				return Ok(true)
 			})
-			Ω(i).Should(Equal(1))
+			Ω(i).Should(Equal(3))
 		})
 
 		It("should correctly execute calls to catch", func() {
 			i := 0
-			Err(errors.New("this is an error")).Then(func(ok interface{}) Option {
+			Err(errors.New("this is an error")).Catch(func(err error) Option {
+				// This should happen.
+				i++
+				Ω(err).Should(HaveOccurred())
+				return Err(err)
+			}).Catch(func(err error) Option {
+				// This should happen.
+				i++
+				Ω(err).Should(HaveOccurred())
+				return Err(err)
+			}).Then(func(ok interface{}) Option {
+				// This should not happen.
 				i++
 				Ω(true).Should(Equal(false))
 				return Ok(true)
 			}).Catch(func(err error) Option {
+				// This should happen.
 				i++
 				Ω(err).Should(HaveOccurred())
-				return Err(nil)
+				return Err(err)
 			})
-			Ω(i).Should(Equal(1))
+			Ω(i).Should(Equal(3))
 		})
 	})
 


### PR DESCRIPTION
Adds the Begin and CoBegin functions which spawn functions onto goroutines and then wait for all goroutines to terminate. This pull request also updates the Process function to take in any number of process functions, and extends the Option type to include Then and Catch for monad-style computations.