### PR TITLE
Guarded objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,46 @@ log.Println("7 =", ret[1])
 
 `Begin` function will use one goroutine per CPU and distribute the functions evenly over each goroutine. `CoBegin` will always use one goroutine per function.
 
+### Guarded Objects
+
+Using the `GuardedObject` you can provide safe concurrent access to an object. Using the `Enter` and `Exit` functions you can guarantee that the object is being accessed mutually exclusively. In addition to this, you can define `Guards` and pass them to `Enter` to make sure that the object is only accessed if a certain boolean condition is true.
+
+Below is an example of a concurrent `Stack`. If it is full, a call to `Push` function will not overflow. Instead, it will wait until the `Stack` is not full and then continue. Similarly, the `Pop` function will not underflow.
+
+```go
+type Stack struct {
+    do.GuardedObject
+
+    i             int
+    items         []interface{}
+    itemsNotEmpty *do.Guard
+    itemsNotFull  *do.Guard
+}
+
+func NewStack() *Stack {
+    s := new(Stack)
+    s.i = 0
+    s.items = make([]interface{}, 10)
+    s.itemsNotEmpty = q.Guard(func() bool { return len(q.items) > 0 })
+    s.itemsNotFull = q.Guard(func() bool { return len(q.items) < 10 })
+    return q
+}
+
+func (s *Stack) Push(item interface{}) {
+    s.Enter(s.isListNotFull)
+    defer s.Exit()
+    s.items[i] = item
+    s.i++
+}
+
+func (s *Stack) Pop() (item interface{}) {
+    s.Enter(s.isListNotEmpty)
+    defer s.Exit()
+    item = s.items[i]
+    s.i--
+}
+```
+
 ## Tests
 
 To run the test suite, install Ginkgo.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ type Stack struct {
 
 func NewStack() *Stack {
     s := new(Stack)
+    s.GuardedObject = do.NewGuardedObject()
     s.i = 0
     s.items = make([]interface{}, 10)
     s.itemsNotEmpty = q.Guard(func() bool { return len(q.items) > 0 })

--- a/guard.go
+++ b/guard.go
@@ -67,7 +67,6 @@ func NewGuardedObject() GuardedObject {
 // must only be used with the GuardedObject that created it.
 func (object *GuardedObject) Guard(condition func() bool) *Guard {
 	guard := newGuard(condition)
-	object.mu = new(sync.RWMutex)
 	object.guards = append(object.guards, guard)
 	return &object.guards[len(object.guards)-1]
 }

--- a/guard.go
+++ b/guard.go
@@ -1,0 +1,122 @@
+package do
+
+import (
+	"sync"
+)
+
+// A Guard is a conditional variable used for entry into a function. It allows
+// a function to wait for a condition to be true before executing. It is not
+// safe to use concurrently.
+type Guard struct {
+	condition     func() bool
+	conditionOpen bool
+	conditionWait chan struct{}
+}
+
+func newGuard(condition func() bool) Guard {
+	guard := Guard{
+		condition:     condition,
+		conditionOpen: condition(),
+		conditionWait: make(chan struct{}, 1),
+	}
+	if guard.conditionOpen {
+		guard.conditionWait <- struct{}{}
+	}
+	return guard
+}
+
+func (guard *Guard) open() {
+	if guard.conditionOpen {
+		return
+	}
+	guard.conditionOpen = true
+	guard.conditionWait <- struct{}{}
+}
+
+func (guard *Guard) close() {
+	if !guard.conditionOpen {
+		return
+	}
+	guard.conditionOpen = false
+	<-guard.conditionWait
+}
+
+func (guard *Guard) wait() {
+	<-guard.conditionWait
+	guard.conditionOpen = false
+}
+
+// A GuardedObject uses Guards to provide safe concurrent access to an object.
+// The object should use a GuardedObject to create Guards, and each function
+// that accesses the object must call the Enter and Exit functions at the
+// beginning and end of the function. A Guard can optionally be passed to the
+// Enter function, as long as the Guard was created using the same
+// GuardedObject. By doing this, the function will no execute until the Guard
+// condition is true.
+type GuardedObject struct {
+	mu     *sync.RWMutex
+	guards []Guard
+}
+
+func NewGuardedObject() GuardedObject {
+	return GuardedObject{
+		mu:     new(sync.RWMutex),
+		guards: make([]Guard, 0),
+	}
+}
+
+// Guard returns a Guard for use with this GuardedObject, that waits for the
+// condition to be true. The Guard condition must be read-only and make no
+// changes to non-local variables.
+func (object *GuardedObject) Guard(condition func() bool) *Guard {
+	guard := newGuard(condition)
+	object.mu = new(sync.RWMutex)
+	object.guards = append(object.guards, guard)
+	return &object.guards[len(object.guards)-1]
+}
+
+// Enter the GuardedObject. Exit must be called after a call to Enter. If a
+// Guard is passed to this function it will block until the Guard condition
+// is true.
+func (object *GuardedObject) Enter(guard *Guard) {
+	if guard != nil {
+		guard.wait()
+	}
+	object.mu.Lock()
+}
+
+// EnterReadOnly will enter the GuardedObject but only acquire a read lock. Any
+// function that uses EnterReadOnly to protect an object must make sure that it
+// does not modify the object. ExitReadOnly must be called after a call to
+// EnterReadOnly.
+func (object *GuardedObject) EnterReadOnly(guard *Guard) {
+	if guard != nil {
+		guard.wait()
+	}
+	object.mu.RLock()
+}
+
+// Exit the GuardedObject. All Guards attached to the GuardedObject will be
+// re-evaluated. This must not be called unless a call to Enter has already
+// been made.
+func (object *GuardedObject) Exit() {
+	object.resolveGuards()
+	object.mu.Unlock()
+}
+
+// ExitReadOnly is the same as Exit, but it must not be called unless a call to
+// EnterReadOnly has already been made.
+func (object *GuardedObject) ExitReadOnly() {
+	object.resolveGuards()
+	object.mu.RUnlock()
+}
+
+func (object *GuardedObject) resolveGuards() {
+	for i := range object.guards {
+		if object.guards[i].condition() {
+			object.guards[i].open()
+		} else {
+			object.guards[i].close()
+		}
+	}
+}

--- a/guard_test.go
+++ b/guard_test.go
@@ -1,10 +1,11 @@
 package do_test
 
 import (
-	"log"
+	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo"
-	// . "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	. "github.com/republicprotocol/go-do"
 )
@@ -12,15 +13,19 @@ import (
 type mockObject struct {
 	GuardedObject
 
-	notifications          []interface{}
-	notificationsLeftGuard *Guard
+	notifications             []interface{}
+	notificationReceived      bool
+	notificationsLeftGuard    *Guard
+	notificationReceivedGuard *Guard
 }
 
-func newMockObject() *mockObject {
+func newMockObject(notifications []interface{}) *mockObject {
 	obj := new(mockObject)
 	obj.GuardedObject = NewGuardedObject()
-	obj.notifications = []interface{}{}
+	obj.notifications = notifications
+	obj.notificationReceived = false
 	obj.notificationsLeftGuard = obj.Guard(func() bool { return len(obj.notifications) > 0 })
+	obj.notificationReceivedGuard = obj.Guard(func() bool { return obj.notificationReceived })
 	return obj
 }
 
@@ -28,7 +33,7 @@ func (obj *mockObject) Notify(notification interface{}) {
 	obj.Enter(nil)
 	defer obj.Exit()
 
-	log.Println("Notify")
+	obj.notificationReceived = true
 	obj.notifications = append(obj.notifications, notification)
 }
 
@@ -36,7 +41,6 @@ func (obj *mockObject) Notification() interface{} {
 	obj.Enter(obj.notificationsLeftGuard)
 	defer obj.Exit()
 
-	log.Println("Notification", len(obj.notifications))
 	ret := obj.notifications[0]
 	if len(obj.notifications) == 1 {
 		obj.notifications = []interface{}{}
@@ -53,30 +57,102 @@ func (obj *mockObject) NotificationsWaiting() int {
 	return len(obj.notifications)
 }
 
+func (obj *mockObject) NotificationReceived() {
+	obj.EnterReadOnly(obj.notificationReceivedGuard)
+	defer obj.ExitReadOnly()
+}
+
 var _ = Describe("Mutual exclusion", func() {
 
-	Context("when using guarded objects", func() {
+	Context("when using a guarded object", func() {
 
-		It("should not produce any racing errors", func() {
-			obj := newMockObject()
-			for {
-				log.Println("=================")
-				CoBegin(func() Option {
-					ps := make([]int, 3)
-					CoForAll(ps, func(i int) {
-						obj.Notification()
+		It("should express liveliness properties on initially closed guards", func() {
+			for n := 0; n < 10; n++ {
+				ins := int64(0)
+				outs := int64(0)
+				obj := newMockObject([]interface{}{})
+				ret := Process(func() Option {
+					CoBegin(func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.NotificationReceived()
+						})
+						return Ok(nil)
+					}, func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.NotificationsWaiting()
+						})
+						return Ok(nil)
+					}, func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.Notification()
+							atomic.AddInt64(&ins, 1)
+						})
+						return Ok(nil)
+					}, func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.Notify(i)
+							atomic.AddInt64(&outs, 1)
+						})
+						return Ok(nil)
 					})
-					return Ok(nil)
-				}, func() Option {
-					ps := make([]int, 3)
-					CoForAll(ps, func(i int) {
-						obj.Notify(i)
-					})
-					return Ok(nil)
+					return Ok(outs - ins)
 				})
+				select {
+				case <-time.Tick(time.Minute):
+					panic("Deadlock detected")
+				case val := <-ret:
+					Ω(val.Ok).Should(Equal(int64(0)))
+				}
+			}
+		})
+
+		It("should express liveliness properties on initially open guards", func() {
+			for n := 0; n < 10; n++ {
+				ins := int64(0)
+				outs := int64(0)
+				obj := newMockObject([]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+				ret := Process(func() Option {
+					CoBegin(func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.NotificationReceived()
+						})
+						return Ok(nil)
+					}, func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.NotificationsWaiting()
+						})
+						return Ok(nil)
+					}, func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.Notification()
+							atomic.AddInt64(&ins, 1)
+						})
+						return Ok(nil)
+					}, func() Option {
+						ps := make([]int, 1000)
+						CoForAll(ps, func(i int) {
+							obj.Notify(i)
+							atomic.AddInt64(&outs, 1)
+						})
+						return Ok(nil)
+					})
+					return Ok(outs - ins)
+				})
+				select {
+				case <-time.Tick(time.Minute):
+					panic("Deadlock detected")
+				case val := <-ret:
+					Ω(val.Ok).Should(Equal(int64(0)))
+				}
 			}
 		})
 
 	})
-
 })

--- a/guard_test.go
+++ b/guard_test.go
@@ -1,0 +1,81 @@
+package do_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	// . "github.com/onsi/gomega"
+
+	. "github.com/republicprotocol/go-do"
+)
+
+type mockObject struct {
+	GuardedObject
+
+	notifications          []interface{}
+	notificationsLeftGuard *Guard
+}
+
+func newMockObject() *mockObject {
+	obj := new(mockObject)
+	obj.GuardedObject = NewGuardedObject()
+	obj.notifications = []interface{}{}
+	obj.notificationsLeftGuard = obj.Guard(func() bool { return len(obj.notifications) > 0 })
+	return obj
+}
+
+func (obj *mockObject) Notify(notification interface{}) {
+	obj.Enter(nil)
+	defer obj.Exit()
+
+	obj.notifications = append(obj.notifications, notification)
+}
+
+func (obj *mockObject) Notification() interface{} {
+	obj.Enter(obj.notificationsLeftGuard)
+	defer obj.Exit()
+
+	ret := obj.notifications[0]
+	if len(obj.notifications) == 1 {
+		obj.notifications = []interface{}{}
+		return ret
+	}
+	obj.notifications = obj.notifications[1:]
+	return ret
+}
+
+func (obj *mockObject) NotificationsWaiting() int {
+	obj.EnterReadOnly(nil)
+	defer obj.ExitReadOnly()
+
+	return len(obj.notifications)
+}
+
+var _ = Describe("Mutual exclusion", func() {
+
+	Context("when using guarded objects", func() {
+
+		It("should not produce any racing errors", func() {
+			obj := newMockObject()
+			CoBegin(func() Option {
+				ps := make([]int, 1000)
+				CoForAll(ps, func(i int) {
+					obj.Notification()
+				})
+				return Ok(nil)
+			}, func() Option {
+				ps := make([]int, 1000)
+				CoForAll(ps, func(i int) {
+					obj.Notify(i)
+				})
+				return Ok(nil)
+			}, func() Option {
+				ps := make([]int, 1000)
+				CoForAll(ps, func(i int) {
+					obj.NotificationsWaiting()
+				})
+				return Ok(nil)
+			})
+		})
+
+	})
+
+})


### PR DESCRIPTION
Added the `GuardedObject`, inspired by the need for Ada protected objects. Really wish Go had better support for this kind of stuff, but this should be good for the majority of use cases. Caveat: the `GuardedObject` does _not_ provide any fairness guarantees.